### PR TITLE
do not check record size in csv.Reader as it must be the exact size

### DIFF
--- a/loader.go
+++ b/loader.go
@@ -144,7 +144,7 @@ func LoadData(file io.Reader, lineConsumer LineConsumer) error {
 
 	return LoadDataWithOptions(file, lineConsumer, LoadDataOptions{
 		delimiter:     ';',
-		nbFields:      8,
+		nbFields:      0, // do not check record size in csv.reader
 		skipFirstLine: false,
 	})
 }


### PR DESCRIPTION
So if the file is updated with new field that we do not have to read the
loading fail...
We already check the size of the slice when building the Departure